### PR TITLE
fix has_choices property for Django 3.0

### DIFF
--- a/factory_generator/generator.py
+++ b/factory_generator/generator.py
@@ -65,7 +65,7 @@ class FactoryFieldGenerator:
         """
         Return `True` if the field has a `choices` attribute
         """
-        return hasattr(self.field, 'choices') and len(self.field.choices) > 0
+        return hasattr(self.field, 'choices') and self.field.choices
 
     @property
     def field_class(self):


### PR DESCRIPTION
Attribute choices value is None if non-existent since Django 3.0 (empty array before)
Avoid error : TypeError: object of type 'NoneType' has no len()